### PR TITLE
Fix setuptools not found when building docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,8 @@
 FROM bitnami/minideb:buster as install
 
 RUN install_packages python3-pip git
+RUN pip3 install setuptools-scm && pip3 install --upgrade setuptools
+
 RUN pip3 --no-cache-dir install pipenv
 ENV LANG C.UTF-8
 ENV LC_ALL C.UTF-8


### PR DESCRIPTION
## Problem
The `ModuleNotFoundError` occurs when building the Docker image:

```zsh
## some other messages...
Collecting distlib<1,>=0.3.0 (from virtualenv->pipenv)
  Downloading https://files.pythonhosted.org/packages/7d/29/694a3a4d7c0e1aef76092e9167fbe372e0f7da055f5dcf4e1313ec21d96a/distlib-0.3.0.zip (571kB)
    Complete output from command python setup.py egg_info:
    Traceback (most recent call last):
      File "<string>", line 1, in <module>
    ModuleNotFoundError: No module named 'setuptools'

    ----------------------------------------
Command "python setup.py egg_info" failed with error code 1 in /tmp/pip-install-tejvracr/distlib/
The command '/bin/sh -c pip3 --no-cache-dir install pipenv' returned a non-zero code: 1
```

## Solution
Add `setuptools` in the `install` stage

```dockerfile
RUN pip3 install setuptools-scm && pip3 install --upgrade setuptools
````